### PR TITLE
Lookup VIP names and propagate them to metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ ct:
 cover:
 	./rebar3 as test cover
 
+rock:
+	./elvis rock
+
 ##
 ## Release targets
 ##

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When you launch a set of tasks with these labels, we distribute them to all of t
 
 #### Caveats
 1. You musn't firewall traffic between the nodes
-2. You musn't change ip_local_port_range
+2. You musn't change `ip_local_port_range`
 3. You must have the `ipset` package installed
 4. You must run a stock kernel from RHEL 7.2+, or Ubuntu 14.04+ LTS
 

--- a/include/minuteman.hrl
+++ b/include/minuteman.hrl
@@ -9,6 +9,12 @@
 -author("sdhillon").
 -author("Tyler Neely").
 
+-record(ct_timer, {
+  id :: integer(),
+  timer_id :: timer:tref(),
+  start_time :: integer()
+  }).
+
 -record(mapping, {
   orig_src_ip,
   orig_src_port,

--- a/test/minuteman_ct_latency_observer_SUITE.erl
+++ b/test/minuteman_ct_latency_observer_SUITE.erl
@@ -1,0 +1,60 @@
+-module(minuteman_ct_latency_observer_SUITE).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("include/minuteman.hrl").
+-include_lib("telemetry/include/telemetry.hrl").
+
+all() -> all(os:cmd("id -u")).
+
+%% root tests
+all("0\n") ->
+  [test_init,
+   test_named_vip_timeout];
+
+%% non root tests
+all(_) -> [].
+
+test_init(_Config) -> ok.
+
+test_named_vip_timeout(_Config) ->
+  IP = {10, 0, 1, 31},
+  Port = 12998,
+  VIPPort = 6000,
+  Name = <<"de8b9dc86.marathon">>,
+
+  % inject an update for this vip
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY,
+                                 {update, [{update, {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}},
+                                                      VIPPort}, riak_dt_orswot},
+                                            {add, {IP, Port} }}]}),
+
+  % find the assigned IP that this minuteman instance gave for this Name
+  [{ip, VIP}] = minuteman_lashup_vip_listener:lookup_vips([{name, Name}]),
+  ID = 100,
+
+  % inject a timeout event
+  {ok, TimerID} = timer:send_after(minuteman_config:tcp_connect_threshold(),
+                                       {check_conn_connected, {ID, IP, Port, VIP, VIPPort}}),
+  ets:insert(connection_timers, #ct_timer{id = ID,
+                                          timer_id = TimerID,
+                                          start_time = erlang:monotonic_time(nano_seconds)}),
+  Msg = {check_conn_connected, {ID, IP, Port, VIP, VIPPort}},
+  Msg = minuteman_ct_latency_observer ! Msg,
+
+  % get the timeout event from telemetry and verify that its there
+  timer:sleep(telemetry_config:interval_seconds()*1000),
+  Metrics = telemetry_store:reap(),
+  [{Item, _}|_] = Metrics#metrics.time_to_counters,
+  {_, {name_tags, mm_connect_failures, Map}} = Item,
+  Name = maps:get(name, Map),
+  <<"11.0.0.91_6000">> = maps:get(vip, Map),
+  ok.
+
+init_per_testcase(_, Config) ->
+  application:set_env(telemetry, interval_seconds, 1),
+  {ok, _} = application:ensure_all_started(minuteman),
+  Config.
+
+end_per_testcase(_, _Config) ->
+  ok = application:stop(minuteman).

--- a/test/minuteman_lashup_vip_listener_SUITE.erl
+++ b/test/minuteman_lashup_vip_listener_SUITE.erl
@@ -1,0 +1,63 @@
+-module(minuteman_lashup_vip_listener_SUITE).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("include/minuteman.hrl").
+
+all() -> all(os:cmd("id -u")).
+
+%% root tests
+all("0\n") ->
+  [test_uninitalized_table,
+   lookup_vip,
+   lookup_failure,
+   lookup_failure2,
+   lookup_failure3];
+
+%% non root tests
+all(_) -> [].
+
+test_uninitalized_table(_Config) ->
+  IP = {10, 0, 1, 10},
+  [] = minuteman_lashup_vip_listener:lookup_vips([{ip, IP}]),
+  ok.
+
+lookup_failure(_Config) ->
+  IP = {10, 0, 1, 10},
+  [{badmatch, IP}] = minuteman_lashup_vip_listener:lookup_vips([{ip, IP}]),
+  Name = <<"foobar.marathon">>,
+  [{badmatch, Name}] = minuteman_lashup_vip_listener:lookup_vips([{name, Name}]),
+  ok.
+
+lookup_failure2(Config) ->
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+                                                       {{tcp, {1, 2, 3, 4}, 5000}, riak_dt_orswot},
+                                                       {add, {{10, 0, 1, 10}, 17780}}}]}),
+  lookup_failure(Config),
+  ok.
+
+lookup_failure3(Config) ->
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+                                                       {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}}, 6000},
+                                                        riak_dt_orswot},
+                                                       {add, {{10, 0, 1, 31}, 12998}}}]}),
+  lookup_failure(Config),
+  ok.
+
+lookup_vip(_Config) ->
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+                                                       {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}}, 6000},
+                                                        riak_dt_orswot},
+                                                       {add, {{10, 0, 1, 31}, 12998}}}]}),
+  [] = minuteman_lashup_vip_listener:lookup_vips([]),
+  [{ip, IP}] = minuteman_lashup_vip_listener:lookup_vips([{name, <<"de8b9dc86.marathon">>}]),
+  [{name, <<"de8b9dc86.marathon">>}] = minuteman_lashup_vip_listener:lookup_vips([{ip, IP}]),
+  ok.
+init_per_testcase(test_uninitalized_table, Config) -> Config;
+init_per_testcase(_, Config) ->
+  {ok, _} = application:ensure_all_started(minuteman),
+  Config.
+
+end_per_testcase(test_uninitalized_table, _Config) -> ok;
+end_per_testcase(_, _Config) ->
+  ok = application:stop(minuteman).


### PR DESCRIPTION
- implemented bi-directional lookup_vips api in minuteman_lashup_vip_listener
- split out a function to generate Tags for metrics which does a lookup for named VIPs
- made ets public for testing
- CT tests
