### PR TITLE
Fixes the issue when backends on overlay are not removed when the agent dies

### DIFF
--- a/src/minuteman_lashup_vip_listener.erl
+++ b/src/minuteman_lashup_vip_listener.erl
@@ -63,7 +63,7 @@
 -type ip_vip() :: {tcp | udp, inet:ip4_address(), inet:port_number()}.
 -type vip_name() :: binary().
 -type named_vip() :: {tcp | udp, {name, {vip_name(), framework_name()}}, inet:port_number()}.
--type vip() :: {ip_vip() | named_vip(), [ip_port()]}.
+-type vip2() :: {ip_vip() | named_vip(), [{inet:ip4_address(), ip_port()}]}.
 
 %%%===================================================================
 %%% API
@@ -104,7 +104,7 @@ init([]) ->
     MinIP = ip_to_integer(minuteman_config:min_named_ip()),
     MaxIP = ip_to_integer(minuteman_config:max_named_ip()),
     MonitorRef = setup_monitor(),
-    {ok, Ref} = lashup_kv_events_helper:start_link(ets:fun2ms(fun({?VIPS_KEY}) -> true end)),
+    {ok, Ref} = lashup_kv_events_helper:start_link(ets:fun2ms(fun({?VIPS_KEY2}) -> true end)),
     State = #state{ref = Ref, max_ip_num = MaxIP, min_ip_num = MinIP, monitorRef = MonitorRef},
     {ok, State}.
 
@@ -255,7 +255,7 @@ rewrite_keys({{RealKey, riak_dt_orswot}, Value}) ->
     {RealKey, Value}.
 
 %% @doc Extracts name based vips. Binds names
--spec(rebind_names([vip()], state()) -> [ip_vip()]).
+-spec(rebind_names([vip2()], state()) -> [ip_vip()]).
 rebind_names(VIPs0, State) ->
     Names0 = [Name || {{_Protocol, {name, Name}, _Portnumber}, _Backends} <- VIPs0],
     Names1 = lists:map(fun({Name, FWName}) -> binary_to_name([Name, FWName]) end, Names0),
@@ -263,7 +263,7 @@ rebind_names(VIPs0, State) ->
     update_name_mapping(Names2, State),
     lists:map(fun(VIP) -> rewrite_name(VIP) end, VIPs0).
 
--spec(rewrite_name(vip()) -> ip_vip()).
+-spec(rewrite_name(vip2()) -> ip_vip()).
 rewrite_name({{Protocol, {name, {Name, FWName}}, PortNum}, BEs}) ->
     FullName = binary_to_name([Name, FWName]),
     [{_, IPNum}] = ets:lookup(name_to_ip, FullName),
@@ -482,17 +482,17 @@ process_vips(Protocol) ->
     VIPs = [
         {
             {{Protocol, {1, 2, 3, 4}, 80}, riak_dt_orswot},
-            [{{10, 0, 3, 46}, 11778}]
+            [{{10, 0, 3, 46}, {10, 0, 3, 46}, 11778}]
         },
         {
             {{Protocol, {name, {<<"/foo">>, <<"marathon">>}}, 80}, riak_dt_orswot},
-            [{{10, 0, 3, 46}, 25458}]
+            [{{10, 0, 3, 46}, {10, 0, 3, 46}, 25458}]
         }
     ],
     Out = process_vips(VIPs, State),
     Expected = [
-        {{Protocol, {1, 2, 3, 4}, 80}, [{{10, 0, 3, 46}, 11778}]},
-        {{Protocol, {11, 0, 0, 36}, 80}, [{{10, 0, 3, 46}, 25458}]}
+        {{Protocol, {1, 2, 3, 4}, 80}, [{{10, 0, 3, 46}, {10, 0, 3, 46}, 11778}]},
+        {{Protocol, {11, 0, 0, 36}, 80}, [{{10, 0, 3, 46}, {10, 0, 3, 46}, 25458}]}
     ],
     ?assertEqual(Expected, Out),
     State.

--- a/test/minuteman_ipvs_SUITE.erl
+++ b/test/minuteman_ipvs_SUITE.erl
@@ -73,14 +73,14 @@ webserver(Pid) ->
 
 add_webserver(VIP, {IP, Port}) ->
     % inject an update for this vip
-    {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update, {VIP, riak_dt_orswot}, {add, {IP, Port} }}]}).
+    {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update, {VIP, riak_dt_orswot}, {add, {IP, {IP, Port}}}}]}).
 
 remove_webserver(VIP, {IP, Port}) ->
     % inject an update for this vip
-    {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update, {VIP, riak_dt_orswot}, {remove, {IP, Port} }}]}).
+    {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update, {VIP, riak_dt_orswot}, {remove, {IP, {IP, Port}}}}]}).
 
 remove_vip(VIP) ->
-    {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{remove, {VIP, riak_dt_orswot}}]}).
+    {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{remove, {VIP, riak_dt_orswot}}]}).
 
 
 test_vip(VIP) ->

--- a/test/minuteman_lashup_vip_listener_SUITE.erl
+++ b/test/minuteman_lashup_vip_listener_SUITE.erl
@@ -52,25 +52,25 @@ lookup_failure(_Config) ->
   ok.
 
 lookup_failure2(Config) ->
-  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update,
                                                        {{tcp, {1, 2, 3, 4}, 5000}, riak_dt_orswot},
-                                                       {add, {{10, 0, 1, 10}, 17780}}}]}),
+                                                       {add, {{10, 0, 1, 10}, {{10, 0, 1, 10}, 17780}}}}]}),
   lookup_failure(Config),
   ok.
 
 lookup_failure3(Config) ->
-  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update,
                                                        {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}}, 6000},
                                                         riak_dt_orswot},
-                                                       {add, {{10, 0, 1, 31}, 12998}}}]}),
+                                                       {add, {{10, 0, 1, 31}, {{10, 0, 1, 31}, 12998}}}}]}),
   lookup_failure(Config),
   ok.
 
 lookup_vip(_Config) ->
-  {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+  {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update,
                                                        {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}}, 6000},
                                                         riak_dt_orswot},
-                                                       {add, {{10, 0, 1, 31}, 12998}}}]}),
+                                                       {add, {{10, 0, 1, 31}, {{10, 0, 1, 31}, 12998}}}}]}),
   [] = minuteman_lashup_vip_listener:lookup_vips([]),
   [{ip, IP}] = minuteman_lashup_vip_listener:lookup_vips([{name, <<"de8b9dc86.marathon">>}]),
   [{name, <<"de8b9dc86.marathon">>}] = minuteman_lashup_vip_listener:lookup_vips([{ip, IP}]),

--- a/test/minuteman_mesos_poller_SUITE.erl
+++ b/test/minuteman_mesos_poller_SUITE.erl
@@ -44,15 +44,13 @@ test_gen_server(_Config) ->
     sys:resume(minuteman_mesos_poller).
 
 test_handle_poll_state(Config) ->
-    AgentIP = {1, 1, 1, 1},
+    AgentIP = {10, 0, 0, 243},
     DataDir = ?config(data_dir, Config),
     %%ok = mnesia:dirty_delete(kv2, [minuteman, vips]),
     {ok, Data} = file:read_file(filename:join(DataDir, "named-base-vips.json")),
     {ok, MesosState} = mesos_state_client:parse_response(Data),
     State = {state, AgentIP, 0},
     minuteman_mesos_poller:handle_poll_state(MesosState, State),
-    LashupValue = lashup_kv:value([minuteman, vips]),
-    [{_, [{{10, 0, 0, 243}, 12049}]}] = LashupValue,
     LashupValue2 = lashup_kv:value([minuteman, vips2]),
-    [{_, [{{1, 1, 1, 1}, {{10, 0, 0, 243}, 12049}}]}] = LashupValue2.
+    [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}] = LashupValue2.
 

--- a/test/minuteman_metrics_SUITE.erl
+++ b/test/minuteman_metrics_SUITE.erl
@@ -95,10 +95,10 @@ test_one_conn(_Config) ->
     ok.
 
 test_named_vip(_Config) ->
-    {ok, _} = lashup_kv:request_op(?VIPS_KEY, {update, [{update,
+    {ok, _} = lashup_kv:request_op(?VIPS_KEY2, {update, [{update,
                                                        {{tcp, {name, {<<"de8b9dc86">>, <<"marathon">>}}, 8080},
                                                         riak_dt_orswot},
-                                                       {add, {{10, 0, 79, 182}, 8080}}}]}),
+                                                       {add, {{10, 0, 79, 182}, {{10, 0, 79, 182}, 8080}}}}]}),
     [{ip, IP}] = minuteman_lashup_vip_listener:lookup_vips([{name, <<"de8b9dc86.marathon">>}]),
     ct:pal("change the testdata if it doesn't match ip: ~p", [IP]),
     push_metrics = erlang:send(minuteman_metrics, push_metrics),


### PR DESCRIPTION
Note: This commit depends on the new key-value format in lashup.
If you are planning to upgrade minuteman then please first
transition to previous commit (which has the transition code)
and then move to this commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/minuteman/93)
<!-- Reviewable:end -->
